### PR TITLE
Add support to Gradle 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.0
+* Add compatibility with AGP 8 (Android Gradle Plugin).
+
 ## 0.4.0
 * Upgrade Kotlin to 1.8.0 and Gradle to 6.8.3
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.caiopo.installer_info'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.8.21'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.caiopo.installer_info'
+    }
+
     compileSdkVersion 30
 
     sourceSets {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: installer_info
 description: Returns information about the method used to install your app.
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/caiopo/flutter-installer-info
 repository: https://github.com/caiopo/flutter-installer-info
 


### PR DESCRIPTION
## Description

Hello, currently the plugin doesn't build when Gradle 8+ is used. That is because the property `namespace` is mandatory.
I included the namespace property with backwards compatibility.