### PR TITLE
Support different Kotlin versions by using jvmTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.1
+* Support different Kotlin versions by using jvmTarget.
+
 ## 0.5.0
 * Add compatibility with AGP 8 (Android Gradle Plugin).
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,9 +35,20 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+    
     defaultConfig {
         minSdkVersion 16
     }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: installer_info
 description: Returns information about the method used to install your app.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/caiopo/flutter-installer-info
 repository: https://github.com/caiopo/flutter-installer-info
 


### PR DESCRIPTION
This is a small fix from my previous PR with Gradle 8 support.
In order to support apps that use newer Kotlin versions than the one the plugin uses, we need to include the jvmTarget options to the gradle file. 